### PR TITLE
Make inject/inject act the same as inject/in

### DIFF
--- a/src/vinyasa/inject.clj
+++ b/src/vinyasa/inject.clj
@@ -85,7 +85,7 @@
 
 (defn inject [& args]
   (->> args
-       (mapcat inject-split-args)
+       inject-split-args
        (mapcat inject-row)
        vec))
 


### PR DESCRIPTION
With the current version of `vinyasa.inject`, I can do the following to inject some functions:

```
(vinyasa.inject/in [alembic.still distill lein])
```

However, the following does **not** work:

```
(vinyasa.inject/inject '[alembic.still distill lein])
```

You actually have to do this in order for the functions to be injected correctly:

```
(vinyasa.inject/inject '[[alembic.still distill lein]])
```

This is quite surprising to me. When I looked at the code, I noticed that [`vinyasa.inject/inject`](https://github.com/zcaudate/vinyasa/blob/b6d48100278a4601fb5e51859349c3b6455221a2/src/vinyasa/inject.clj#L88) had two `mapcat`s instead of just one (like [`vinyasa.inject/in`](https://github.com/zcaudate/vinyasa/blob/b6d48100278a4601fb5e51859349c3b6455221a2/src/vinyasa/inject.clj#L95)). This pull request removes the extra `mapcat`, so that

```
(vinyasa.inject/inject '[alembic.still distill lein])
```

will work correctly.