### PR TITLE
Change maven central host to repo1.maven.org

### DIFF
--- a/docs/lucid-aether.html
+++ b/docs/lucid-aether.html
@@ -99,7 +99,7 @@
                      :url "http://clojars.org/repo"}
                     {:id "central",
                      :type "default",
-                     :url "http://central.maven.org/maven2/"}],
+                     :url "http://repo1.maven.org/maven2/"}],
      :system org.eclipse.aether.RepositorySystem
      :session org.eclipse.aether.RepositorySystemSession})</code></pre></div><div class="entry"><span id="entry__lucid_aether__deploy_artifact"></span><div class="entry-description"><h4><b>deploy-artifact&nbsp<a data-scroll="" href="#entry__lucid_aether__">^</a></b></h4><p><i>deploys artifacts to the given coordinate</i></p></div><div class="entry-option"><h6><a href="https://www.github.com/zcaudate/lucidity/blob/master/src/lucid/aether.clj#L137-L160" target="_blank">v&nbsp;1.2</a></h6><div><input class="source-toggle" id="entry__pre_lucid_aether__deploy_artifact" type="checkbox" /><label class="source-toggle" for="entry__pre_lucid_aether__deploy_artifact"></label><pre class="source"><code class="clojure">(defn deploy-artifact
   ([coord {:keys [artifacts repository] :as opts}]

--- a/src/lucid/aether/base.clj
+++ b/src/lucid/aether/base.clj
@@ -9,7 +9,7 @@
                    :url "https://clojars.org/repo"}
                   {:id "central"
                    :type "default"
-                   :url "https://central.maven.org/maven2/"}]})
+                   :url "https://repo1.maven.org/maven2/"}]})
 
 (defrecord Aether [])
 
@@ -27,7 +27,7 @@
                         :url \"http://clojars.org/repo\"}
                        {:id \"central\",
                        :type \"default\",
-                        :url \"http://central.maven.org/maven2/\"}],
+                        :url \"http://repo1.maven.org/maven2/\"}],
         :system org.eclipse.aether.RepositorySystem
         :session org.eclipse.aether.RepositorySystemSession})"
   {:added "1.1"}

--- a/test/lucid/aether/base_test.clj
+++ b/test/lucid/aether/base_test.clj
@@ -12,6 +12,6 @@
                        :url "https://clojars.org/repo"}
                       {:id "central",
                        :type "default",
-                       :url "https://central.maven.org/maven2/"}],
+                       :url "https://repo1.maven.org/maven2/"}],
        :system org.eclipse.aether.RepositorySystem
        :session org.eclipse.aether.RepositorySystemSession}))


### PR DESCRIPTION
Hey!

I'm experiencing an issue when trying to use `lucid.package/list-dependencies`. Here's a minimal example:

```
(ns lucid-test.core
  (:require [lucid.package :as lp]))

(defn -main [& args]
  (println (lp/list-dependencies '[[org.clojure/core.match "0.3.0-alpha4"]])))
```

Results in the following exception:

```
Caused by: org.eclipse.aether.collection.DependencyCollectionException: Failed to read artifact descriptor for org.clojure:core.match:jar:0.3.0-alpha4
        at org.eclipse.aether.internal.impl.DefaultDependencyCollector.collectDependencies(DefaultDependencyCollector.java:208)
        at org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveDependencies(DefaultRepositorySystem.java:341)
        ... 45 more
Caused by: org.eclipse.aether.resolution.ArtifactDescriptorException: Failed to read artifact descriptor for org.clojure:core.match:jar:0.3.0-alpha4
        at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.loadPom(DefaultArtifactDescriptorReader.java:329)
        at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.readArtifactDescriptor(DefaultArtifactDescriptorReader.java:217)
        at org.eclipse.aether.internal.impl.DefaultDependencyCollector.collectDependencies(DefaultDependencyCollector.java:202)
        ... 46 more
Caused by: org.eclipse.aether.resolution.ArtifactResolutionException: Could not transfer artifact org.clojure:core.match:pom:0.3.0-alpha4 from/to central (https://central.maven.o
rg/maven2/): hostname in certificate didn't match: <central.maven.org> != <repo1.maven.org> OR <repo1.maven.org>
        at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:444)
        at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts(DefaultArtifactResolver.java:246)
        at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact(DefaultArtifactResolver.java:223)
        at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.loadPom(DefaultArtifactDescriptorReader.java:314)
        ... 48 more
Caused by: org.eclipse.aether.transfer.ArtifactTransferException: Could not transfer artifact org.clojure:core.match:pom:0.3.0-alpha4 from/to central (https://central.maven.org/m
aven2/): hostname in certificate didn't match: <central.maven.org> != <repo1.maven.org> OR <repo1.maven.org>
        at org.eclipse.aether.connector.basic.ArtifactTransportListener.transferFailed(ArtifactTransportListener.java:43)
        at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run(BasicRepositoryConnector.java:355)
        at org.eclipse.aether.util.concurrency.RunnableErrorForwarder$1.run(RunnableErrorForwarder.java:67)
        at org.eclipse.aether.connector.basic.BasicRepositoryConnector$DirectExecutor.execute(BasicRepositoryConnector.java:581)
        at org.eclipse.aether.connector.basic.BasicRepositoryConnector.get(BasicRepositoryConnector.java:249)
        at org.eclipse.aether.internal.impl.DefaultArtifactResolver.performDownloads(DefaultArtifactResolver.java:520)
        at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:421)
        ... 51 more
Caused by: javax.net.ssl.SSLException: hostname in certificate didn't match: <central.maven.org> != <repo1.maven.org> OR <repo1.maven.org>
        at org.apache.http.conn.ssl.AbstractVerifier.verify(AbstractVerifier.java:238)
        at org.apache.http.conn.ssl.BrowserCompatHostnameVerifier.verify(BrowserCompatHostnameVerifier.java:54)
        at org.apache.http.conn.ssl.AbstractVerifier.verify(AbstractVerifier.java:159)
        at org.apache.http.conn.ssl.AbstractVerifier.verify(AbstractVerifier.java:140)
        at org.apache.http.conn.ssl.SSLSocketFactory.verifyHostname(SSLSocketFactory.java:561)
        at org.apache.http.conn.ssl.SSLSocketFactory.connectSocket(SSLSocketFactory.java:536)
        at org.apache.http.conn.ssl.SSLSocketFactory.connectSocket(SSLSocketFactory.java:403)
        at org.apache.http.impl.conn.DefaultClientConnectionOperator.openConnection(DefaultClientConnectionOperator.java:177)
        at org.apache.http.impl.conn.ManagedClientConnectionImpl.open(ManagedClientConnectionImpl.java:304)
        at org.apache.http.impl.client.DefaultRequestDirector.tryConnect(DefaultRequestDirector.java:611)
        at org.apache.http.impl.client.DefaultRequestDirector.execute(DefaultRequestDirector.java:446)
        at org.apache.http.impl.client.AbstractHttpClient.doExecute(AbstractHttpClient.java:863)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:72)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:57)
        at org.apache.http.impl.client.DecompressingHttpClient.execute(DecompressingHttpClient.java:158)
        at org.eclipse.aether.transport.http.HttpTransporter.execute(HttpTransporter.java:318)
        at org.eclipse.aether.transport.http.HttpTransporter.implGet(HttpTransporter.java:274)
        at org.eclipse.aether.spi.connector.transport.AbstractTransporter.get(AbstractTransporter.java:59)
        at org.eclipse.aether.connector.basic.BasicRepositoryConnector$GetTaskRunner.runTask(BasicRepositoryConnector.java:447)
        at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run(BasicRepositoryConnector.java:350)
        ... 56 more
```

However if I redefine maven sources dynamically like so:

```
(ns lucid-test.core
  (:require [lucid.package :as lp]))

(defn -main [& args]
  (with-redefs [lucid.aether.base/+defaults+ {:repositories [{:id "clojars"
                                                              :type "default"
                                                              :url "https://clojars.org/repo"}
                                                             {:id "central"
                                                              :type "default"
                                                              :url "https://repo1.maven.org/maven2/"}]}]
  (println (lp/list-dependencies '[[org.clojure/core.match "0.3.0-alpha4"]]))))
```

It works fine. So maybe it should just be `repo1` everywhere like [here](https://github.com/zcaudate/lucidity/blob/4b41e76dc050d0f7565f33f5a9e4feb5d23ae995/src/lucid/package/pom.clj#L75)? I'm using Clojure `1.8.0` with Java `1.8.0_101` on OSX.

Cheers,
Saulius