### PR TITLE
Fixed security issue when docs are served over HTTPS

### DIFF
--- a/resources/theme/bolton/article.html
+++ b/resources/theme/bolton/article.html
@@ -20,7 +20,7 @@
   <link rel="stylesheet" href="css/bolton.css">
   <link rel="stylesheet" href="css/bolton-api.css">
   <link rel="stylesheet" href="css/bolton-highlight.css">
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400">
   
 </head>
 

--- a/resources/theme/bolton/home.html
+++ b/resources/theme/bolton/home.html
@@ -20,7 +20,7 @@
   <link rel="stylesheet" href="css/bolton.css">
   <link rel="stylesheet" href="css/bolton-api.css">
   <link rel="stylesheet" href="css/bolton-highlight.css">
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400">
 
 </head>
 

--- a/resources/theme/stark/article.html
+++ b/resources/theme/stark/article.html
@@ -20,7 +20,7 @@
   <link rel="stylesheet" href="css/stark.css">
   <link rel="stylesheet" href="css/stark-api.css">
   <link rel="stylesheet" href="css/stark-highlight.css">
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400">
   
 </head>
 

--- a/resources/theme/stark/home.html
+++ b/resources/theme/stark/home.html
@@ -20,7 +20,7 @@
   <link rel="stylesheet" href="css/stark.css">
   <link rel="stylesheet" href="css/stark-api.css">
   <link rel="stylesheet" href="css/stark-highlight.css">
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400">
 
 </head>
 


### PR DESCRIPTION
When lucid.publish docs are published over HTTPS, a modern browser will warn about content linked through HTTP.  This small fix should take care of this problem.  Per [this post](https://www.paulirish.com/2010/the-protocol-relative-url/), it is considered best practice to use HTTPS when in doubt, as long as the resource is available over HTTPS.  The alternative of using protocol-relative URL is not recommended anymore.